### PR TITLE
Fix an issue related to "-" chars in title

### DIFF
--- a/export-notes.scpt
+++ b/export-notes.scpt
@@ -199,9 +199,16 @@ on makeValidFilename(fileName)
     end repeat
 
     -- Remove trailing dash if present
-    if validFileName ends with "-" then
-        set validFileName to text 1 through -2 of validFileName
-    end if
+    -- Could just always remove all -
+    -- But will just do that on error
+    try
+        if validFileName ends with "-" then
+            set validFileName to text 1 through -2 of validFileName
+        end if
+    on error errMsg number errNum
+        log "Error removing trailing dash: " & errMsg
+        set validFileName to my replaceText("-", "", validFileName)
+    end try
 
     return validFileName
 end makeValidFilename


### PR DESCRIPTION
When attempting to export my notes I received the following error.
./export-notes.scpt:8297:8314: execution error: Can’t get text 1 thru -2 of "-". (-1728)
I added a try catch so that if this error occurs it falls back to removing all "-" characters.