### PR TITLE
fix: use python3 instead of python for macOS compatibility

### DIFF
--- a/exportnotes.zsh
+++ b/exportnotes.zsh
@@ -384,7 +384,7 @@ while [[ $# -gt 0 ]]; do
         --query|-Q)
             # Run a search query against exported notes and exit
             shift
-            python "$SCRIPT_DIR/query_notes.py" "$@"
+            python3 "$SCRIPT_DIR/query_notes.py" "$@"
             exit $?
             ;;
         --all-formats|--all|-a)
@@ -572,29 +572,29 @@ fi
 # Conditionally execute the image extraction script
 if [[ "${NOTES_EXPORT_EXTRACT_IMAGES}" == "true" ]]; then
     echo "Extracting images..."
-    python "$SCRIPT_DIR/extract_images.py"
+    python3 "$SCRIPT_DIR/extract_images.py"
 fi
 
 # Conditionally execute the conversion scripts
 if [[ "${NOTES_EXPORT_CONVERT_TO_MARKDOWN}" == "true" ]]; then
     echo "Converting to Markdown..."
-    python "$SCRIPT_DIR/convert_to_markdown.py"
+    python3 "$SCRIPT_DIR/convert_to_markdown.py"
 fi
 
 if [[ "${NOTES_EXPORT_CONVERT_TO_PDF}" == "true" ]]; then
     echo "Converting to PDF..."
-    python "$SCRIPT_DIR/convert_to_pdf.py"
+    python3 "$SCRIPT_DIR/convert_to_pdf.py"
 fi
 
 if [[ "${NOTES_EXPORT_CONVERT_TO_WORD}" == "true" ]]; then
     echo "Converting to Word..."
-    python "$SCRIPT_DIR/convert_to_word.py"
+    python3 "$SCRIPT_DIR/convert_to_word.py"
 fi
 
 # Optionally set filesystem dates to match Apple Notes dates
 if [[ "${NOTES_EXPORT_SET_FILE_DATES}" == "true" ]]; then
     echo "Setting file dates to match Apple Notes..."
-    python "$SCRIPT_DIR/set_file_dates.py"
+    python3 "$SCRIPT_DIR/set_file_dates.py"
 fi
 
 # Sync back to Apple Notes if requested
@@ -616,7 +616,7 @@ if [[ "${NOTES_EXPORT_SYNC}" == "true" ]]; then
     if [[ -n "${NOTES_EXPORT_FILTER_ACCOUNTS}" ]]; then
         SYNC_ARGS="$SYNC_ARGS --filter-accounts ${NOTES_EXPORT_FILTER_ACCOUNTS}"
     fi
-    python "$SCRIPT_DIR/sync_to_notes.py" $SYNC_ARGS
+    python3 "$SCRIPT_DIR/sync_to_notes.py" $SYNC_ARGS
 
     # Auto-regenerate formats after sync if settings say so
     # Only runs when not in dry-run mode
@@ -634,13 +634,13 @@ print(','.join(formats))
         if [[ -n "$REGEN_ARGS" ]]; then
             echo "Auto-regenerating formats after sync: $REGEN_ARGS"
             if [[ "$REGEN_ARGS" == *"html"* ]]; then
-                python "$SCRIPT_DIR/extract_images.py"
+                python3 "$SCRIPT_DIR/extract_images.py"
             fi
             if [[ "$REGEN_ARGS" == *"pdf"* ]]; then
-                python "$SCRIPT_DIR/convert_to_pdf.py"
+                python3 "$SCRIPT_DIR/convert_to_pdf.py"
             fi
             if [[ "$REGEN_ARGS" == *"word"* ]]; then
-                python "$SCRIPT_DIR/convert_to_word.py"
+                python3 "$SCRIPT_DIR/convert_to_word.py"
             fi
         fi
     fi
@@ -649,7 +649,7 @@ fi
 # Sync notes to Qdrant vector database if requested
 if [[ "${NOTES_EXPORT_UPDATE_QDRANT}" == "true" ]]; then
     echo "Syncing notes to Qdrant..."
-    python "$SCRIPT_DIR/qdrant_integration.py" sync
+    python3 "$SCRIPT_DIR/qdrant_integration.py" sync
 fi
 
 # Optionally deactivate and remove the venv


### PR DESCRIPTION
## Summary
Changes all `python` references to `python3` in `exportnotes.zsh` for better macOS compatibility.

## Problem
The script uses `python` command which doesn't exist on modern macOS systems (only `python3` is available via Homebrew). This causes the export to fail silently when running:
- `extract_images.py`
- `convert_to_markdown.py`
- `convert_to_pdf.py`
- `convert_to_word.py`
- `set_file_dates.py`
- `sync_to_notes.py`
- `qdrant_integration.py`
- `query_notes.py`

## Solution
Changed all `python` references to `python3` on lines: 387, 575, 581, 586, 591, 597, 619, 640, 643, 652.

## Testing
Verified that the script now works correctly with the changes.